### PR TITLE
Moved launchedProcessLogs outside of loop in extractDiagnostics

### DIFF
--- a/PXCTestKit/Command/RunTests/RunTestsWorker.swift
+++ b/PXCTestKit/Command/RunTests/RunTestsWorker.swift
@@ -38,8 +38,9 @@ final class RunTestsWorker {
     }
 
     func extractDiagnostics(fileManager: RunTestsFileManager) throws {
+        let launchedProcessLogs = simulator.simulatorDiagnostics.launchedProcessLogs()
         for application in applications {
-            guard let diagnostics = simulator.simulatorDiagnostics.launchedProcessLogs().first(where: { $0.0.processName == application.name })?.value else { continue }
+            guard let diagnostics = launchedProcessLogs.first(where: { $0.0.processName == application.name })?.value else { continue }
             let destinationPath = fileManager.urlFor(worker: self).path
             try diagnostics.writeOut(toDirectory: destinationPath)
         }


### PR DESCRIPTION
@plu The call of launchedProcessLogs() during runs seems to take a lot of time (up to 15 minutes for some of our test schemes). I have moved it outside the _for_ loop and although it still takes a lot of time to retrieve the logs, it is doing so only once per simulator.