### PR TITLE
Add ShutdownSimulatorsCommand

### DIFF
--- a/PXCTestKit/Command/Context.swift
+++ b/PXCTestKit/Command/Context.swift
@@ -185,3 +185,12 @@ extension RunTestsCommand {
     }
 
 }
+
+extension ShutdownSimulatorsCommand {
+    
+    struct Context {
+        let deviceSet: URL
+    }
+    
+}
+

--- a/PXCTestKit/Command/ShutdownSimulatorsCommand.swift
+++ b/PXCTestKit/Command/ShutdownSimulatorsCommand.swift
@@ -1,0 +1,37 @@
+//
+//  ShutdownSimulatorsCommand.swift
+//  pxctest
+//
+//  Created by Chris Danford on 3/2/17.
+//  Copyright © 2017 Johannes Plunien. All rights reserved.
+//
+
+import FBSimulatorControl
+import Foundation
+
+final class ShutdownSimulatorsCommand: Command {
+    
+    let context: Context
+    
+    init(context: Context) {
+        self.context = context
+    }
+    
+    func abort() {
+    }
+    
+    func run() throws {
+        let configuration = FBSimulatorControlConfiguration(deviceSetPath: context.deviceSet.path)
+        let control = try FBSimulatorControl.withConfiguration(configuration)
+        
+        let allSimulators = [control.pool.allocatedSimulators, control.pool.unallocatedSimulators].joined();
+
+        for simulator in allSimulators {
+            FBControlCoreGlobalConfiguration.defaultLogger().log("\(simulator)")
+            if simulator.state != .shuttingDown {
+                try simulator.shutdownSimulator()
+            }
+        }
+    }
+    
+}

--- a/PXCTestKit/CommandLineInterface.swift
+++ b/PXCTestKit/CommandLineInterface.swift
@@ -141,6 +141,19 @@ import Foundation
                 let commit = infoDictionary["GIT_COMMIT"]!
                 print("pxctest \(version) (\(commit))")
             }
+            
+            $0.command("shutdown-simulators",
+                       Option<ExistingFileURLOption>("deviceset", ExistingFileURLOption(url: URL(fileURLWithPath: FBSimulatorControlConfiguration.defaultDeviceSetPath())), description: "Path to the Simulator device set.")
+            ) { (deviceSet) in
+                let context = ShutdownSimulatorsCommand.Context(
+                    deviceSet: deviceSet.url
+                )
+                
+                CommandLineInterface.command = ShutdownSimulatorsCommand(context: context)
+                
+                try CommandLineInterface.command?.run()
+            }
+            
         }.run()
     }
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,13 @@ $ xcrun simctl --set /tmp/test-simulators list
 
 The `Booted` state here however does not mean "is ready for launching apps or running tests". After booting a device it enters the `Booted` state quickly, but still showing the loading bar above the Springboard (you can see that if you boot them via `Simulator.app` and keep watching the state that `xcrun simctl` reports).
 
+When you're finished running tests, you may wish to shut down running simulators to release their resources.
+
+```shell
+$ pxctest shutdown-simulators \
+    --deviceset /tmp/test-simulators
+```
+
 ## Development
 
 ```shell

--- a/pxctest.xcodeproj/project.pbxproj
+++ b/pxctest.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		3ECD52091E0533F700183EE4 /* JRSwizzle.m in Sources */ = {isa = PBXBuildFile; fileRef = 3ECD52081E0533F700183EE4 /* JRSwizzle.m */; };
 		3EE721D81DFC080500EF99E1 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EE721D71DFC080500EF99E1 /* main.m */; };
 		3EFC1B9F1DF26FEF0011E88B /* Crash.app in Resources */ = {isa = PBXBuildFile; fileRef = 3EFC1B9D1DF26FEF0011E88B /* Crash.app */; };
+		83A67C0A1E6895DB00CED483 /* ShutdownSimulatorsCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A67C091E6895DB00CED483 /* ShutdownSimulatorsCommand.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -315,6 +316,7 @@
 		3EE721D41DFC080500EF99E1 /* libpxctest-list-tests.dylib */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libpxctest-list-tests.dylib"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3EE721D71DFC080500EF99E1 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		3EFC1B9D1DF26FEF0011E88B /* Crash.app */ = {isa = PBXFileReference; lastKnownFileType = wrapper.application; path = Crash.app; sourceTree = "<group>"; };
+		83A67C091E6895DB00CED483 /* ShutdownSimulatorsCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShutdownSimulatorsCommand.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -555,6 +557,7 @@
 				3EBFCB031E14C739007C22C4 /* BootSimulators */,
 				3EBFCB051E14C739007C22C4 /* ListTests */,
 				3EBFCB071E14C739007C22C4 /* RunTests */,
+				83A67BFF1E6895AD00CED483 /* ShutdownSimulators */,
 			);
 			path = Command;
 			sourceTree = "<group>";
@@ -660,6 +663,14 @@
 				0554B6B91E07925B00299699 /* pxctest-list-tests.xcconfig */,
 			);
 			path = "pxctest-list-tests";
+			sourceTree = "<group>";
+		};
+		83A67BFF1E6895AD00CED483 /* ShutdownSimulators */ = {
+			isa = PBXGroup;
+			children = (
+				83A67C091E6895DB00CED483 /* ShutdownSimulatorsCommand.swift */,
+			);
+			name = ShutdownSimulators;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1013,6 +1024,7 @@
 				05E1E35C1E3DCC34004F67B8 /* TestReporterAdapter.swift in Sources */,
 				05E1E3231E3DA76D004F67B8 /* String+PXCTestKit.swift in Sources */,
 				3E4CA70B1DFBCA5B005216A3 /* SignalHandler.swift in Sources */,
+				83A67C0A1E6895DB00CED483 /* ShutdownSimulatorsCommand.swift in Sources */,
 				3EBFCB0D1E14C739007C22C4 /* RunTestsCommand.swift in Sources */,
 				3EBFCB0E1E14C739007C22C4 /* RunTestsError.swift in Sources */,
 				05E3DE6E1DED319D005A1459 /* Command.swift in Sources */,


### PR DESCRIPTION
This adds a `shutdown-simulators` command to stop simulators that you've booted.  This releases resources held by the simulators and lets you delete the `deviceset` directory (otherwise, the running simulators will keep writing files there and recreate it. 

```shell
$ pxctest shutdown-simulators \
    --deviceset /tmp/test-simulators
```

Context: I'm wanting to run multiple sets of tests in parallel on a single host.  Each test run has a unique directory for deviceset, and I need the simulators to shut down after every run or else a few test runs seems to exhaust system resources and my Mac beachballs until force rebooted.