### PR TITLE
Add syslog retrieval

### DIFF
--- a/PXCTestKit/Command/RunTests/RunTestsWorker.swift
+++ b/PXCTestKit/Command/RunTests/RunTestsWorker.swift
@@ -54,9 +54,11 @@ final class RunTestsWorker {
     }
 
     func extractDiagnostics(fileManager: RunTestsFileManager) throws {
+        let syslog = simulator.simulatorDiagnostics.syslog()
+        let destinationPath = fileManager.urlFor(worker: self).path
+        try syslog.writeOut(toDirectory: destinationPath)
         for error in errors {
             for crash in error.crashes {
-                let destinationPath = fileManager.urlFor(worker: self).path
                 try crash.writeOut(toDirectory: destinationPath)
             }
         }


### PR DESCRIPTION
@plu Would it be possible to get this merged in? It generates a file with the syslogs for each device which complements the already generated TestRunner logs. I have tested this and there is no delay added while generating these logs. Thanks