### PR TITLE
Adds podspec and scripts to release and publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,20 @@ $ pxctest \
     --testrun derivedData/Build/Intermediates/CodeCoverage/Products/MyApp_iphonesimulator10.1-i386.xctestrun
 ```
 
+## Release version update
+
+1. Update `Info.plist` > `CFBundleShortVersionString`
+2. Update `CHANGELOG.md`
+3. Ensure the latest stable Xcode version is installed and `xcode-select`ed.
+4. From project root directory run `./scripts/release.sh`
+5. Create a GitHub release: https://github.com/plu/pxctest/releases/new
+    * Specify the tag you just pushed in the dropdown.
+    * Set the release title to the new version number.
+    * Add the changelog section to the release description text box.
+    * Upload the portable zip you just built to the GitHub release binaries.
+    * Click "Publish release".
+6. Publish to Homebrew and CocoaPods: `./scripts/publish.sh`
+
 ## License
 
 [MIT](LICENSE)

--- a/pxctest.podspec
+++ b/pxctest.podspec
@@ -1,0 +1,10 @@
+Pod::Spec.new do |s|
+  s.name           = 'pxctest'
+  s.version        = `./scripts/get_version.sh`
+  s.summary        = 'Execute tests in parallel on multiple iOS Simulators'
+  s.homepage       = 'https://github.com/plu/pxctest'
+  s.license        = { :type => 'MIT', :file => 'LICENSE' }
+  s.author         = { 'Johannes Plunien' => 'plu@pqpq.de' }
+  s.source         = { :http => "#{s.homepage}/releases/download/#{s.version}/portable_pxctest.zip" }
+  s.preserve_paths = '*'
+end

--- a/scripts/get_version.sh
+++ b/scripts/get_version.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+PXCTEST_PLIST='pxctest/info.plist'
+NEW_VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$PXCTEST_PLIST")
+
+echo "$NEW_VERSION"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+
+brew update && brew bump-formula-pr --tag=$(shell git describe --tags) --revision=$(shell git rev-parse HEAD) pxctest
+pod trunk push pxctest.podspec

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -e
+
+PXCTEST_PLIST='pxctest/info.plist'
+NEW_VERSION="$(./scripts/get_version.sh)"
+
+echo "New version is $NEW_VERSION"
+
+NEW_RELEASE_DIR="build/releases/$NEW_VERSION"
+
+echo "Cleaning release directory"
+
+rm -rf "$NEW_RELEASE_DIR"
+
+BUILT_BIN_NAME='pxctest'
+BUILT_BIN_PATH="$NEW_RELEASE_DIR/bin/$BUILT_BIN_NAME"
+BUILT_FRAMEWORK_NAME='PXCTestKit.framework'
+BUILT_FRAMEWORK_PATH="$NEW_RELEASE_DIR/Frameworks/$BUILT_FRAMEWORK_NAME"
+LICENSE_NAME='LICENSE'
+LICENSE_PATH="./$LICENSE_NAME"
+
+echo "Building to $NEW_RELEASE_DIR"
+
+./scripts/build.sh "$NEW_RELEASE_DIR"
+
+echo "Creating portable release"
+
+PORTABLE_RELEASE_DIR="$NEW_RELEASE_DIR/portable_pxctest"
+
+mkdir -p "$PORTABLE_RELEASE_DIR"
+
+cp -f "$BUILT_BIN_PATH" "$PORTABLE_RELEASE_DIR"
+cp -fR "$BUILT_FRAMEWORK_PATH" "$PORTABLE_RELEASE_DIR"
+cp -f "$LICENSE_PATH" "$PORTABLE_RELEASE_DIR"
+
+(cd "$PORTABLE_RELEASE_DIR"; zip -yr - "$BUILT_BIN_NAME" "$BUILT_FRAMEWORK_NAME" "$LICENSE_NAME") > "$PORTABLE_RELEASE_DIR.zip"
+
+echo "Tagging release"
+
+git commit -a -m "release $NEW_VERSION"
+git tag -a "$NEW_VERSION" -m "release $NEW_VERSION"
+git push origin master
+git push origin "$NEW_VERSION"
+
+echo "Release complete; see https://github.com/plu/pxctest#release-version-update for next steps."


### PR DESCRIPTION
Thanks for making this! I have implemented it in our app to run our test matrix on 4 simulators in parallel. It has almost halved our CI build times 😄 

We would like the ability to include a versioned instance of the built binary as a CocoaPod dependency in our app. We have a few reasons for wanting this: 
1. to cache this along with our other pods so CI builds don't need to wait for `brew install`
2. to only rely on a single dependency manager
3. to have a versioned instance of this tool

I borrowed heavily from Swiftlint's implementation of this; see
https://github.com/realm/SwiftLint/blob/master/SwiftLint.podspec
https://github.com/realm/SwiftLint/blob/master/Makefile

I do not know how you normally publish to Homebrew but I added a couple of scripts with the intent of minimizing the number of steps & places needed to update the version etc.

Let me know if you like this approach. 

Next steps would be to register as a pod owner here: https://guides.cocoapods.org/making/getting-setup-with-trunk.html and try releasing a new version (0.3.4?).